### PR TITLE
2024.08.20 Code review

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,4 @@ members = [
     "core",
     "tools"]
 
+resolver = "2"

--- a/core/src/prelude.rs
+++ b/core/src/prelude.rs
@@ -2,30 +2,31 @@ use std::collections::HashMap;
 
 /**
  * Трейт для работы с конфигами роутов для приложения.
- * Роут - это пара входящий адрес -- список адресатов, 
+ * Роут - это пара входящий адрес -- список адресатов,
  * на который надо переслать запрос.
- * 
+ *
  * Пример:
  * Входящий запрос /foo/bar
  * Перенаправляем на:
  * https://some-host:9090/foo/bar,
- * https://another-host:9898/foo/bar 
+ * https://another-host:9898/foo/bar
  */
+#[allow(dead_code)]
 pub trait Config {
     /**
      * По урлу понимает на какие адреса надо переслать запросы
      */
-    fn get_dests(&self, source_addr: &String) -> Option<&Vec<String>>;
+    fn get_dests(&self, source_addr: &str) -> Option<&Vec<String>>;
 
     /**
-     * Добавляет пару урл - новые адресаты 
+     * Добавляет пару урл - новые адресаты
      */
     fn add_dests(self, source_addr: String, destinations: Vec<String>);
 
     /**
      * Удаляет пару урл - новые адреса
      */
-    fn delete_dests(self, source_addr: &String);
+    fn delete_dests(self, source_addr: &str);
 }
 
 #[derive(Default)]
@@ -33,7 +34,8 @@ pub struct HashMapConfig {
     _dict: HashMap<String, Vec<String>>,
 }
 
-impl Config for HashMapConfig {
+#[allow(dead_code)]
+impl HashMapConfig {
     fn get_dests(&self, source_addr: &String) -> Option<&Vec<String>> {
         self._dict.get(source_addr)
     }


### PR DESCRIPTION
Minor changes of code.
Added macro #[allow(dead_code)] to prevent warnings from cargo checker (prelude.rs)
Added hard defining of resolver version (needed for rust toolchains > 1.51.0 for workspaces) [https://doc.rust-lang.org/edition-guide/rust-2021/default-cargo-resolver.html](Rust Book)
Function _hello_ now uses smart pointer Box to prevent bytes copying into tokio threads.
Redone of function _check_result_ (match pattern)